### PR TITLE
Compendium error handling

### DIFF
--- a/ProphetBot/cogs/dashboards.py
+++ b/ProphetBot/cogs/dashboards.py
@@ -249,7 +249,10 @@ class Dashboards(commands.Cog):
             g: PlayerGuild = await get_or_create_guild(self.bot.db, dGuild.id)
             total, inactive = await get_guild_character_summary_stats(self.bot, dGuild.id)
 
-            progress=g.get_xp_float(total, inactive) if g.get_xp_float(total, inactive) <= 1 else 1
+            try:
+                progress=g.get_xp_float(total, inactive) if g.get_xp_float(total, inactive) <= 1 else 1
+            except ZeroDivisionError:
+                return
 
             # Start Drawing
             width = 500

--- a/ProphetBot/cogs/guilds.py
+++ b/ProphetBot/cogs/guilds.py
@@ -301,7 +301,6 @@ class Guilds(commands.Cog):
 
         # Reset weekly stats
         async with self.bot.db.acquire() as conn:
-            await conn.execute(update_guild(g))
             async for row in await conn.execute(get_characters(g.id)):
                 if row is not None:
                     character: PlayerCharacter = CharacterSchema(self.bot.compendium).load(row)
@@ -355,6 +354,10 @@ class Guilds(commands.Cog):
                     shop: Shop = ShopSchema(self.bot.compendium).load(row)
                     shop.seeks_remaining = 1 + shop.network
                     await conn.execute(update_shop(shop))
+
+        # Guild
+        async with self.bot.db.acquire() as conn:
+            await conn.execute(update_guild(g))
 
         end = timer()
 

--- a/ProphetBot/compendium.py
+++ b/ProphetBot/compendium.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from timeit import default_timer as timer
+from types import NoneType
 
 from ProphetBot.models.db_objects.item_objects import ItemBlacksmith, ItemWondrous, ItemConsumable, ItemScroll
 from ProphetBot.models.schemas.category_schema import *
@@ -132,7 +133,7 @@ class Compendium:
 
     def get_object(self, node: str, value: str | int = None):
         if hasattr(self, node):
-            if len(self.__getattribute__(node)[0]) > 0:
+            if len(self.__getattribute__(node)) > 0:
                 try:
                     if isinstance(value, int):
                         return self.__getattribute__(node)[0][value]
@@ -141,6 +142,7 @@ class Compendium:
                 except KeyError:
                     return None
             else:
+                raise AttributeError(f"{node} has not been populated yet")
                 return None
         else:
             raise KeyError(f"{node} does not exist in the compendium")

--- a/ProphetBot/compendium.py
+++ b/ProphetBot/compendium.py
@@ -131,10 +131,17 @@ class Compendium:
             log.info(f"COMPENDIUM: Items reloaded in [ {end - start:.2f} ]s")
 
     def get_object(self, node: str, value: str | int = None):
-        try:
-            if isinstance(value, int):
-                return self.__getattribute__(node)[0][value]
+        if hasattr(self, node):
+            if len(self.__getattribute__(node)[0]) > 0:
+                try:
+                    if isinstance(value, int):
+                        return self.__getattribute__(node)[0][value]
+                    else:
+                        return self.__getattribute__(node)[1][value]
+                except KeyError:
+                    return None
             else:
-                return self.__getattribute__(node)[1][value]
-        except KeyError:
+                return None
+        else:
+            raise KeyError(f"{node} does not exist in the compendium")
             return None

--- a/init.py
+++ b/init.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import sys
 import traceback
-from datetime import datetime
 from os import listdir
 import discord
 from discord import Intents, ApplicationContext, Embed
@@ -55,7 +54,7 @@ for filename in listdir('ProphetBot/cogs'):
 @bot.command()
 async def ping(ctx):
     print("Pong")
-    await ctx.send(f'Pong! Latency is {round(bot.latency * 1000)}ms.')
+    await ctx.send(f'Pong! Latency is {round(bot.latency * 1000)}ms.')\
 
 @bot.command(name="asay")
 @commands.check(is_admin)
@@ -84,6 +83,8 @@ async def on_application_command_error(ctx: ApplicationContext, error):
 
     if isinstance(error, discord.errors.CheckFailure):
         return await ctx.respond(f'You do not have required permissions for `{ctx.command}`')
+    if isinstance(error.original, AttributeError):
+        return await ctx.respond(f"Try again in a minute, and if doesn't work let us know")
     else:
         log.warning("Error in command: '{}'".format(ctx.command))
         for line in traceback.format_exception(type(error), error, error.__traceback__):


### PR DESCRIPTION
1. Updated weekly reset function moving the guild DB write to the end 

2. Update the compendium get_object function to raise exceptions and do checks

3. Updated the generic exception handler for the bot to check for attribute errors thrown (limited cases) and have a try again verbiage versus letting us know. In instances where the bot is restarting this should handle 99% of them, otherwise we can always run a /reload compendium